### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A todo list server built with the Model Context Protocol (MCP) that supports both stdio and HTTP transports.
 
+<a href="https://glama.ai/mcp/servers/@CalamityAdam/mcp-todo">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CalamityAdam/mcp-todo/badge" alt="Todo MCP server" />
+</a>
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [MCP Todo](https://glama.ai/mcp/servers/@CalamityAdam/mcp-todo) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@CalamityAdam/mcp-todo">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CalamityAdam/mcp-todo/badge" alt="Todo MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.